### PR TITLE
Fix code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/backend/src/main/java/com/guitar/tutorial/service/TutorialService.java
+++ b/backend/src/main/java/com/guitar/tutorial/service/TutorialService.java
@@ -36,6 +36,9 @@ public class TutorialService {
     }
 
     public Resource getFile(Path tutorialsPath, String fileName, String extension) throws IOException {
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid file name");
+        }
         Path filePath = tutorialsPath.resolve(fileName + "." + extension).normalize();
         logger.info("Fetching file: {}", filePath);
 


### PR DESCRIPTION
Fixes [https://github.com/pdelebarre/guitar-tutorial-app/security/code-scanning/6](https://github.com/pdelebarre/guitar-tutorial-app/security/code-scanning/6)

To fix the problem, we need to validate the `fileName` parameter to ensure it does not contain any path traversal sequences or invalid characters. This can be done by checking for the presence of "..", "/", or "\\" in the `fileName`. If any of these characters are found, we should throw an `IllegalArgumentException`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
