### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/backend/src/main/java/com/guitar/tutorial/service/VideoStreamingService.java
+++ b/backend/src/main/java/com/guitar/tutorial/service/VideoStreamingService.java
@@ -28,9 +28,19 @@ public class VideoStreamingService {
     // Method to stream video files by song ID with range request support
     public ResponseEntity<Resource> streamVideo(String song, HttpServletRequest request, String tutorialsDirectory)
             throws IOException {
+        // Validate the song parameter to prevent path traversal attacks
+        if (song.contains("..") || song.contains("/") || song.contains("\\")) {
+            throw new IllegalArgumentException("Invalid song identifier");
+        }
+
         // Locate the video file for the given song ID in the external tutorials
         // directory
-        Path videoPath = Paths.get(tutorialsDirectory).resolve(song+".mp4");
+        Path videoPath = Paths.get(tutorialsDirectory).resolve(song + ".mp4").normalize();
+
+        // Ensure the resolved path is within the tutorials directory
+        if (!videoPath.startsWith(Paths.get(tutorialsDirectory).normalize())) {
+            throw new IllegalArgumentException("Invalid song identifier");
+        }
 
         // Check if the file exists
         if (!Files.exists(videoPath)) {


### PR DESCRIPTION
Fixes [https://github.com/pdelebarre/guitar-tutorial-app/security/code-scanning/3](https://github.com/pdelebarre/guitar-tutorial-app/security/code-scanning/3)

To fix the problem, we need to validate the `song` parameter to ensure it does not contain any path traversal characters or sequences. We can achieve this by checking for the presence of "..", "/", or "\\" in the `song` parameter and rejecting the input if any of these are found. Additionally, we can ensure that the resolved path stays within the intended directory.

1. Add validation to check for path traversal characters in the `song` parameter.
2. Ensure that the resolved path is within the `tutorialsDirectory`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
